### PR TITLE
Update Agent-Versions.sql

### DIFF
--- a/sql-query-export/Agent-Versions.sql
+++ b/sql-query-export/Agent-Versions.sql
@@ -12,7 +12,7 @@ ds.family AS "Software_Family",
 ds.version AS "Software_Version",
 ds.software_class AS "Software_Class"
 FROM dim_asset_software das
-JOIN dim_software ds USING(software_id)
-JOIN dim_asset da ON da.asset_id = das.asset_id
-WHERE ds.vendor like'Rapid7%'
+JOIN dim_software ds ON das.software_id=ds.software_id
+JOIN dim_asset da ON da.asset_id=das.asset_id
+WHERE ds.name = 'Rapid7 Insight Agent'
 ORDER BY ds.name ASC


### PR DESCRIPTION
Changed the WHERE statement to look specifically for the software name of "Rapid7 Insight Agent" instead of vendor "Rapid7" because that was bringing in the Collector, Console/Engine, and Scan Assistant

Also changed the JOIN for dim_software to get rid of the USING and JOIN with an ON statement

## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
