### PR TITLE
Update Vulnerabilities-Remediated-Within-SLA.sql

### DIFF
--- a/data-warehouse-sql-queries/Vulnerabilities-Remediated-Within-SLA.sql
+++ b/data-warehouse-sql-queries/Vulnerabilities-Remediated-Within-SLA.sql
@@ -9,6 +9,6 @@ case when (select extract (day from rd.day - vfd.date)) <= 30 then 'yes'
 else 'no'
 end sla_met
 from fact_asset_vulnerability_finding_date vfd
-join fact_asset_vulnerability_remediation_date rd using (vulnerability_id)
+join fact_asset_vulnerability_remediation_date rd ON (rd.vulnerability_id = vfd.vulnerability_id AND rd.asset_id = vfd.asset_id)
 where vfd.critical_vulnerabilities = '1' or
 vfd.severe_vulnerabilities = '1'


### PR DESCRIPTION
Fixed JOIN

It was joining fact_asset_vulnerability_remediation_date on JUST vulnerability_id causing it to relate all vuln remediation with all assets that had that vuln rather than the remediations specific to that asset.

added an and in the join to join on vuln id and asset id.

## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
